### PR TITLE
Update methods with Testnet API [Delivers #155215565]

### DIFF
--- a/packages/identity-claims/src/createProfileMetaIdentityClaim.js
+++ b/packages/identity-claims/src/createProfileMetaIdentityClaim.js
@@ -27,15 +27,25 @@ import { createVerifiedIdentityClaimObject } from '@meta.js/identity-claims'
  * This is a self-issued claim, usually referencing a Swarm hash of profile data
  *
  * @param  {String} claimMessage      Raw identity claim message
+ * @param  {String} graph             META Claims Graph name
  * @param  {Object} issuer            Claim issuer data object
  * @param  {String} issuer.id         META Identity `id` of claim issuer
  * @param  {String} issuer.privateKey Private key of claim issuer
  * @param  {String} subProperty       Type of profile claim contained in `claimMessage`
  * @return {Object}                   Verified META Identity Claim object
  */
-const createProfileMetaIdentityClaim = (claimMessage, issuer, subProperty) => {
+const createProfileMetaIdentityClaim = (
+  claimMessage,
+  graph,
+  issuer,
+  subProperty
+) => {
   if (typeof claimMessage === 'undefined' || typeof claimMessage !== 'string') {
     throw new Error('`claimMessage` is undefined or not of type string.')
+  }
+
+  if (typeof graph === 'undefined' || typeof graph !== 'string') {
+    throw new Error('`graph` is undefined or not of type string.')
   }
 
   if (typeof issuer === 'undefined' || typeof issuer !== 'object') {
@@ -61,6 +71,7 @@ const createProfileMetaIdentityClaim = (claimMessage, issuer, subProperty) => {
 
   return createVerifiedIdentityClaimObject(
     claimMessage,
+    graph,
     {
       id: issuer.id,
       privateKey: issuer.privateKey,

--- a/packages/identity-claims/src/createVerifiableIdentityClaimObject.js
+++ b/packages/identity-claims/src/createVerifiableIdentityClaimObject.js
@@ -29,6 +29,7 @@ import { signMessage } from '@meta.js/identity-claims'
  * @param  {String} account.address    Account Ethereum address
  * @param  {String} account.privateKey Account private key
  * @param  {String} claimMessage       Raw identity claim message
+ * @param  {String} graph              META Claims Graph name
  * @param  {String} subject            META Identity `id` of subject (hash of `username`)
  * @param  {Object} extraData          Any extra properties to add to identity claim object
  * @return {Object}                    META Identity Claim object
@@ -36,6 +37,7 @@ import { signMessage } from '@meta.js/identity-claims'
 const createVerifiableIdentityClaimObject = (
   account,
   claimMessage,
+  graph,
   subject,
   extraData = {}
 ) => {
@@ -61,6 +63,10 @@ const createVerifiableIdentityClaimObject = (
     throw new Error('`claimMessage` is undefined or not of type string.')
   }
 
+  if (typeof graph === 'undefined' || typeof graph !== 'string') {
+    throw new Error('`graph` is undefined or not of type string.')
+  }
+
   if (typeof subject === 'undefined' || typeof subject !== 'string') {
     throw new Error('`subject` is undefined or not of type string.')
   }
@@ -74,6 +80,7 @@ const createVerifiableIdentityClaimObject = (
       address: account.address,
       claimHash: bufferToHex(sha3(claimMessage)),
       claimMessage: claimMessage,
+      graph: graph,
       signature: signMessage(claimMessage, account.privateKey),
       subject: subject,
     },

--- a/packages/identity-claims/src/createVerifiedIdentityClaimObject.js
+++ b/packages/identity-claims/src/createVerifiedIdentityClaimObject.js
@@ -22,9 +22,10 @@
 import { ecsign, sha3, toBuffer, toRpcSig } from 'ethereumjs-util'
 
 /**
- * Create a valid META Identity Claim object to add to META Claims index
+ * Create a valid META Identity Claim object to add to a META Claims Graph
  *
  * @param  {String} claimMessage      Raw claim value
+ * @param  {Object} graph             META Claims Graph name
  * @param  {Object} issuer            Claim issuer data object
  * @param  {String} issuer.id         META Identity `id` of claim issuer
  * @param  {String} issuer.privateKey Private key of claim issuer
@@ -34,12 +35,17 @@ import { ecsign, sha3, toBuffer, toRpcSig } from 'ethereumjs-util'
  */
 const createVerifiedIdentityClaimObject = (
   claimMessage,
+  graph,
   issuer,
   property,
   subject
 ) => {
   if (typeof claimMessage === 'undefined' || typeof claimMessage !== 'string') {
     throw new Error('`claimMessage` is undefined or not of type string.')
+  }
+
+  if (typeof graph === 'undefined' || typeof graph !== 'string') {
+    throw new Error('`graph` is undefined or not of type string.')
   }
 
   if (typeof issuer === 'undefined' || typeof issuer !== 'object') {
@@ -91,6 +97,7 @@ const createVerifiedIdentityClaimObject = (
   // return verified identity claim object
   return {
     claim: claimMessage,
+    graph: graph,
     issuer: issuer.id,
     property: property,
     signature: signature,

--- a/packages/identity-claims/src/followMetaIdentity.js
+++ b/packages/identity-claims/src/followMetaIdentity.js
@@ -32,15 +32,20 @@ import { META_ID_FOLLOW_CLAIM_PROPERTY } from '@meta.js/shared'
  * made about another META ID
  *
  * @param  {Array}  claims            Set of META Identity Claims to verify
+ * @param  {Object} graph             META Claims Graph name
  * @param  {Object} issuer            META Identity initiating the follow claim
  * @param  {String} issuer.id         META Identity `id` of claim issuer
  * @param  {String} issuer.privateKey Private key of claim issuer
  * @param  {String} subject           META Identity `id` receiving the follow claim
  * @return {Object}                   Verified META Identity Follow Claim
  */
-const followMetaIdentity = (claims, issuer, subject) => {
+const followMetaIdentity = (claims, graph, issuer, subject) => {
   if (typeof claims === 'undefined' || !Array.isArray(claims)) {
     throw new Error('`claims` is undefined or not an array.')
+  }
+
+  if (typeof graph === 'undefined' || typeof graph !== 'string') {
+    throw new Error('`graph` is undefined or not of type string.')
   }
 
   if (typeof issuer === 'undefined' || typeof issuer !== 'object') {
@@ -88,6 +93,7 @@ const followMetaIdentity = (claims, issuer, subject) => {
 
   return createVerifiedIdentityClaimObject(
     claimMessage,
+    graph,
     issuer,
     property,
     subject

--- a/packages/identity-claims/test/createProfileMetaIdentityClaim.spec.js
+++ b/packages/identity-claims/test/createProfileMetaIdentityClaim.spec.js
@@ -1,5 +1,6 @@
 const metaIdentityClaims = require('../dist/meta-identity-claims')
 
+const claim = require('./fixtures/claim.json')
 const issuer = require('./fixtures/issuer.json')
 const profileClaim = require('./fixtures/profile-claim.json')
 const verifiedProfileClaim = require('./fixtures/verified-profile-claim.json')
@@ -10,12 +11,14 @@ describe('@meta.js/identity-claims :: createProfileMetaIdentityClaim', () => {
 
     const actual = metaIdentityClaims.createProfileMetaIdentityClaim(
       claimMessage,
+      claim.graph,
       issuer,
       subProperty
     )
 
     const expected = {
       claim: claimMessage,
+      graph: claim.graph,
       issuer: issuer.id,
       property: verifiedProfileClaim.property,
       signature: verifiedProfileClaim.signature,
@@ -44,10 +47,34 @@ describe('@meta.js/identity-claims :: createProfileMetaIdentityClaim', () => {
     expect(actual).toThrow()
   })
 
+  it('Should throw an error if graph is undefined', () => {
+    const actual = () =>
+      metaIdentityClaims.createProfileMetaIdentityClaim(claimMessage)
+
+    expect(actual).toThrow()
+  })
+
+  it('Should throw an error if graph is not of type string', () => {
+    const { claimMessage, subProperty } = profileClaim
+
+    const actual = () =>
+      metaIdentityClaims.createProfileMetaIdentityClaim(
+        claimMessage,
+        { graph: claim.graph },
+        issuer,
+        subProperty
+      )
+
+    expect(actual).toThrow()
+  })
+
   it('Should throw an error if issuer is undefined', () => {
     const { claimMessage } = profileClaim
     const actual = () =>
-      metaIdentityClaims.createProfileMetaIdentityClaim(claimMessage)
+      metaIdentityClaims.createProfileMetaIdentityClaim(
+        claimMessage,
+        claim.graph
+      )
 
     expect(actual).toThrow()
   })
@@ -58,6 +85,7 @@ describe('@meta.js/identity-claims :: createProfileMetaIdentityClaim', () => {
     const actual = () =>
       metaIdentityClaims.createProfileMetaIdentityClaim(
         claimMessage,
+        claim.graph,
         'issuer',
         subProperty
       )
@@ -69,7 +97,11 @@ describe('@meta.js/identity-claims :: createProfileMetaIdentityClaim', () => {
     issuer.id = { id: issuer.id }
 
     const actual = () =>
-      metaIdentityClaims.createProfileMetaIdentityClaim(claimMessage, issuer)
+      metaIdentityClaims.createProfileMetaIdentityClaim(
+        claimMessage,
+        claim.graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
@@ -78,7 +110,11 @@ describe('@meta.js/identity-claims :: createProfileMetaIdentityClaim', () => {
     delete issuer.id
 
     const actual = () =>
-      metaIdentityClaims.createProfileMetaIdentityClaim(claimMessage, issuer)
+      metaIdentityClaims.createProfileMetaIdentityClaim(
+        claimMessage,
+        claim.graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
@@ -87,7 +123,11 @@ describe('@meta.js/identity-claims :: createProfileMetaIdentityClaim', () => {
     issuer.privateKey = { privateKey: issuer.privateKey }
 
     const actual = () =>
-      metaIdentityClaims.createProfileMetaIdentityClaim(claimMessage, issuer)
+      metaIdentityClaims.createProfileMetaIdentityClaim(
+        claimMessage,
+        claim.graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
@@ -96,7 +136,11 @@ describe('@meta.js/identity-claims :: createProfileMetaIdentityClaim', () => {
     delete issuer.privateKey
 
     const actual = () =>
-      metaIdentityClaims.createProfileMetaIdentityClaim(claimMessage, issuer)
+      metaIdentityClaims.createProfileMetaIdentityClaim(
+        claimMessage,
+        claim.graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
@@ -105,16 +149,25 @@ describe('@meta.js/identity-claims :: createProfileMetaIdentityClaim', () => {
     const { claimMessage, subProperty } = profileClaim
 
     const actual = () =>
-      metaIdentityClaims.createProfileMetaIdentityClaim(claimMessage, issuer, {
-        subProperty,
-      })
+      metaIdentityClaims.createProfileMetaIdentityClaim(
+        claimMessage,
+        claim.graph,
+        issuer,
+        {
+          subProperty,
+        }
+      )
 
     expect(actual).toThrow()
   })
 
   it('Should throw an error if subProperty is undefined', () => {
     const actual = () =>
-      metaIdentityClaims.createProfileMetaIdentityClaim(claimMessage, issuer)
+      metaIdentityClaims.createProfileMetaIdentityClaim(
+        claimMessage,
+        claim.graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
@@ -123,9 +176,14 @@ describe('@meta.js/identity-claims :: createProfileMetaIdentityClaim', () => {
     const { claimMessage, subProperty } = profileClaim
 
     const actual = () =>
-      metaIdentityClaims.createProfileMetaIdentityClaim(claimMessage, issuer, {
-        subProperty,
-      })
+      metaIdentityClaims.createProfileMetaIdentityClaim(
+        claimMessage,
+        claim.graph,
+        issuer,
+        {
+          subProperty,
+        }
+      )
 
     expect(actual).toThrow()
   })

--- a/packages/identity-claims/test/createVerifiableIdentityClaimObject.spec.js
+++ b/packages/identity-claims/test/createVerifiableIdentityClaimObject.spec.js
@@ -9,6 +9,7 @@ describe('@meta.js/identity-claims :: createVerifiableIdentityClaimObject', () =
     const actual = metaIdentityClaims.createVerifiableIdentityClaimObject(
       account,
       claim.claimMessage,
+      claim.graph,
       subject.id,
       claim.extraData
     )
@@ -17,6 +18,7 @@ describe('@meta.js/identity-claims :: createVerifiableIdentityClaimObject', () =
       address: account.address,
       claimHash: claim.claimHash,
       claimMessage: claim.claimMessage,
+      graph: claim.graph,
       signature: claim.signature,
       subject: subject.id,
       accessToken: claim.extraData.accessToken,
@@ -44,11 +46,33 @@ describe('@meta.js/identity-claims :: createVerifiableIdentityClaimObject', () =
     expect(actual).toThrow()
   })
 
-  it('Should throw an error if subject is undefined', () => {
+  it('Should throw an error if graph is undefined', () => {
     const actual = () =>
       metaIdentityClaims.createVerifiableIdentityClaimObject(
         account,
         claim.claimMessage
+      )
+
+    expect(actual).toThrow()
+  })
+
+  it('Should throw an error if graph is not of type string', () => {
+    const actual = () =>
+      metaIdentityClaims.createVerifiableIdentityClaimObject(
+        account,
+        claim.claimMessage,
+        { graph: claim.graph }
+      )
+
+    expect(actual).toThrow()
+  })
+
+  it('Should throw an error if subject is undefined', () => {
+    const actual = () =>
+      metaIdentityClaims.createVerifiableIdentityClaimObject(
+        account,
+        claim.claimMessage,
+        claim.graph
       )
 
     expect(actual).toThrow()
@@ -59,6 +83,7 @@ describe('@meta.js/identity-claims :: createVerifiableIdentityClaimObject', () =
       metaIdentityClaims.createVerifiableIdentityClaimObject(
         account,
         claim.claimMessage,
+        claim.graph,
         { subject: subject.id }
       )
 
@@ -70,6 +95,7 @@ describe('@meta.js/identity-claims :: createVerifiableIdentityClaimObject', () =
       metaIdentityClaims.createVerifiableIdentityClaimObject(
         account,
         claim.claimMessage,
+        claim.graph,
         subject.id,
         claim.extraData.accessToken
       )

--- a/packages/identity-claims/test/createVerifiedIdentityClaimObject.spec.js
+++ b/packages/identity-claims/test/createVerifiedIdentityClaimObject.spec.js
@@ -9,6 +9,7 @@ describe('@meta.js/identity-claims :: createVerifiedIdentityClaimObject', () => 
   it('Should return a valid verified META Identity Claim object', () => {
     const actual = metaIdentityClaims.createVerifiedIdentityClaimObject(
       claim.claimMessage,
+      claim.graph,
       issuer,
       claim.property,
       subject.id
@@ -16,6 +17,7 @@ describe('@meta.js/identity-claims :: createVerifiedIdentityClaimObject', () => 
 
     const expected = {
       claim: claim.claimMessage,
+      graph: claim.graph,
       issuer: issuer.id,
       property: claim.property,
       signature: verifiedClaim.signature,
@@ -32,11 +34,35 @@ describe('@meta.js/identity-claims :: createVerifiedIdentityClaimObject', () => 
   })
 
   it('Should throw an error if claimMessage is not of type string', () => {
-    const { claimMessage, property } = claim
+    const { claimMessage, graph, property } = claim
 
     const actual = () =>
       metaIdentityClaims.createVerifiedIdentityClaimObject(
         { claimMessage },
+        graph,
+        issuer,
+        property
+      )
+
+    expect(actual).toThrow()
+  })
+
+  it('Should throw an error if graph is undefined', () => {
+    const { claimMessage } = claim
+
+    const actual = () =>
+      metaIdentityClaims.createVerifiedIdentityClaimObject(claimMessage)
+
+    expect(actual).toThrow()
+  })
+
+  it('Should throw an error if graph is not of type string', () => {
+    const { claimMessage, graph, property } = claim
+
+    const actual = () =>
+      metaIdentityClaims.createVerifiedIdentityClaimObject(
+        claimMessage,
+        { graph },
         issuer,
         property
       )
@@ -45,19 +71,21 @@ describe('@meta.js/identity-claims :: createVerifiedIdentityClaimObject', () => 
   })
 
   it('Should throw an error if issuer is undefined', () => {
-    const { claimMessage } = claim
+    const { claimMessage, graph } = claim
+
     const actual = () =>
-      metaIdentityClaims.createVerifiedIdentityClaimObject(claimMessage)
+      metaIdentityClaims.createVerifiedIdentityClaimObject(claimMessage, graph)
 
     expect(actual).toThrow()
   })
 
   it('Should throw an error if issuer is not of type object', () => {
-    const { claimMessage, property } = claim
+    const { claimMessage, graph, property } = claim
 
     const actual = () =>
       metaIdentityClaims.createVerifiedIdentityClaimObject(
         claimMessage,
+        graph,
         [issuer],
         property
       )
@@ -66,56 +94,85 @@ describe('@meta.js/identity-claims :: createVerifiedIdentityClaimObject', () => 
   })
 
   it('Should throw an error if issuer id is not of type string', () => {
+    const { claimMessage, graph } = claim
+
     issuer.id = { id: issuer.id }
 
     const actual = () =>
-      metaIdentityClaims.createVerifiedIdentityClaimObject(claimMessage, issuer)
+      metaIdentityClaims.createVerifiedIdentityClaimObject(
+        claimMessage,
+        graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
 
   it('Should throw an error if issuer id is undefined', () => {
+    const { claimMessage, graph } = claim
+
     delete issuer.id
 
     const actual = () =>
-      metaIdentityClaims.createVerifiedIdentityClaimObject(claimMessage, issuer)
+      metaIdentityClaims.createVerifiedIdentityClaimObject(
+        claimMessage,
+        graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
 
   it('Should throw an error if issuer privateKey is not of type string', () => {
+    const { claimMessage, graph } = claim
+
     issuer.privateKey = { privateKey: issuer.privateKey }
 
     const actual = () =>
-      metaIdentityClaims.createVerifiedIdentityClaimObject(claimMessage, issuer)
+      metaIdentityClaims.createVerifiedIdentityClaimObject(
+        claimMessage,
+        graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
 
   it('Should throw an error if issuer privateKey is undefined', () => {
+    const { claimMessage, graph } = claim
+
     delete issuer.privateKey
 
     const actual = () =>
-      metaIdentityClaims.createVerifiedIdentityClaimObject(claimMessage, issuer)
+      metaIdentityClaims.createVerifiedIdentityClaimObject(
+        claimMessage,
+        graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
 
   it('Should throw an error if property is undefined', () => {
-    const { claimMessage } = claim
+    const { claimMessage, graph } = claim
 
     const actual = () =>
-      metaIdentityClaims.createVerifiedIdentityClaimObject(claimMessage, issuer)
+      metaIdentityClaims.createVerifiedIdentityClaimObject(
+        claimMessage,
+        graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
 
   it('Should throw an error if property is not of type string', () => {
-    const { claimMessage, property } = claim
+    const { claimMessage, graph, property } = claim
 
     const actual = () =>
       metaIdentityClaims.createVerifiedIdentityClaimObject(
         claimMessage,
+        graph,
         issuer,
         { property }
       )
@@ -124,11 +181,12 @@ describe('@meta.js/identity-claims :: createVerifiedIdentityClaimObject', () => 
   })
 
   it('Should throw an error if subject is undefined', () => {
-    const { claimMessage, property } = claim
+    const { claimMessage, graph, property } = claim
 
     const actual = () =>
       metaIdentityClaims.createVerifiedIdentityClaimObject(
         claimMessage,
+        graph,
         issuer,
         property
       )
@@ -137,11 +195,12 @@ describe('@meta.js/identity-claims :: createVerifiedIdentityClaimObject', () => 
   })
 
   it('Should throw an error if subject is not of type string', () => {
-    const { claimMessage, property } = claim
+    const { claimMessage, graph, property } = claim
 
     const actual = () =>
       metaIdentityClaims.createVerifiedIdentityClaimObject(
         claimMessage,
+        graph,
         issuer,
         property,
         { subject: subject.id }

--- a/packages/identity-claims/test/fixtures/claim.json
+++ b/packages/identity-claims/test/fixtures/claim.json
@@ -4,6 +4,7 @@
   "extraData": {
     "accessToken": "BQABMqi19NoMMXFhmpnQpm8aU_m85oKqTjgH_8BPmz2G2Vlj2TLWHQ09HAEarNml6brWGDggQj5qHSEDiNwXJPQ_NqPBtVuHL6ScipjpsxXuho6ySuWWULz2Ipaqqe74kxmiobQRS8wkHl6gPP8KIfO0TU1Q"
   },
+  "graph": "ray.meta",
   "property": "meta.id",
   "signature": "0x34e54b455a6700fcc784302815846dc10b84834bc03f07a3d58a7af91c8ca34910d0716b735c580675edfacb164a6e2f9b14a768cb6825b73c24eee2ed59d0e601"
 }

--- a/packages/identity-claims/test/fixtures/verified-claim.json
+++ b/packages/identity-claims/test/fixtures/verified-claim.json
@@ -1,5 +1,6 @@
 {
   "claim": "ray.id.meta",
+  "graph": "ray.meta",
   "issuer": "0x9271978a0651b4e0eb61a1162c16edc3c20a23380c5861040a07ac0326693895",
   "property": "meta.id",
   "signature": "0x2466555fa2ace795fcc7f1572963e8728baf1066948d3832231834efddae703c1b85715c34b5ac0a1517b364aeff7fc144ef9136b8df45e27fdd595682fdbe8b00",

--- a/packages/identity-claims/test/followMetaIdentity.spec.js
+++ b/packages/identity-claims/test/followMetaIdentity.spec.js
@@ -1,5 +1,6 @@
 const metaIdentityClaims = require('../dist/meta-identity-claims')
 
+const claim = require('./fixtures/claim.json')
 const followClaim = require('./fixtures/follow-claim.json')
 const issuer = require('./fixtures/issuer.json')
 const subject = require('./fixtures/subject.json')
@@ -12,12 +13,14 @@ describe('@meta.js/identity-claims :: followMetaIdentity', () => {
 
     const actual = metaIdentityClaims.followMetaIdentity(
       [verifiedClaim],
+      claim.graph,
       issuer,
       subject.id
     )
 
     const expected = {
       claim: subject.id,
+      graph: claim.graph,
       issuer: issuer.id,
       property: followClaim.property,
       signature: verifiedFollowClaim.signature,
@@ -31,7 +34,12 @@ describe('@meta.js/identity-claims :: followMetaIdentity', () => {
     delete verifiedClaim.issuerAddress
 
     const actual = () =>
-      metaIdentityClaims.followMetaIdentity([verifiedClaim], issuer, subject.id)
+      metaIdentityClaims.followMetaIdentity(
+        [verifiedClaim],
+        claim.graph,
+        issuer,
+        subject.id
+      )
 
     expect(actual).toThrow()
   })
@@ -48,15 +56,31 @@ describe('@meta.js/identity-claims :: followMetaIdentity', () => {
     expect(actual).toThrow()
   })
 
-  it('Should throw an error if issuer is undefined', () => {
+  it('Should throw an error if graph is undefined', () => {
     const actual = () => metaIdentityClaims.followMetaIdentity([verifiedClaim])
+
+    expect(actual).toThrow()
+  })
+
+  it('Should throw an error if graph is not of type string', () => {
+    const actual = () =>
+      metaIdentityClaims.followMetaIdentity(verifiedClaim, [claim.graph])
+
+    expect(actual).toThrow()
+  })
+
+  it('Should throw an error if issuer is undefined', () => {
+    const actual = () =>
+      metaIdentityClaims.followMetaIdentity([verifiedClaim], claim.graph)
 
     expect(actual).toThrow()
   })
 
   it('Should throw an error if issuer is not of type object', () => {
     const actual = () =>
-      metaIdentityClaims.followMetaIdentity([verifiedClaim], [issuer])
+      metaIdentityClaims.followMetaIdentity([verifiedClaim], claim.graph, [
+        issuer,
+      ])
 
     expect(actual).toThrow()
   })
@@ -65,7 +89,11 @@ describe('@meta.js/identity-claims :: followMetaIdentity', () => {
     issuer.id = { id: issuer.id }
 
     const actual = () =>
-      metaIdentityClaims.followMetaIdentity([verifiedClaim], issuer)
+      metaIdentityClaims.followMetaIdentity(
+        [verifiedClaim],
+        claim.graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
@@ -74,7 +102,11 @@ describe('@meta.js/identity-claims :: followMetaIdentity', () => {
     delete issuer.id
 
     const actual = () =>
-      metaIdentityClaims.followMetaIdentity([verifiedClaim], issuer)
+      metaIdentityClaims.followMetaIdentity(
+        [verifiedClaim],
+        claim.graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
@@ -83,7 +115,11 @@ describe('@meta.js/identity-claims :: followMetaIdentity', () => {
     issuer.privateKey = { privateKey: issuer.privateKey }
 
     const actual = () =>
-      metaIdentityClaims.followMetaIdentity([verifiedClaim], issuer)
+      metaIdentityClaims.followMetaIdentity(
+        [verifiedClaim],
+        claim.graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
@@ -92,23 +128,36 @@ describe('@meta.js/identity-claims :: followMetaIdentity', () => {
     delete issuer.privateKey
 
     const actual = () =>
-      metaIdentityClaims.followMetaIdentity([verifiedClaim], issuer)
+      metaIdentityClaims.followMetaIdentity(
+        [verifiedClaim],
+        claim.graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
 
   it('Should throw an error if subject is undefined', () => {
     const actual = () =>
-      metaIdentityClaims.followMetaIdentity([verifiedClaim], issuer)
+      metaIdentityClaims.followMetaIdentity(
+        [verifiedClaim],
+        claim.graph,
+        issuer
+      )
 
     expect(actual).toThrow()
   })
 
   it('Should throw an error if subject is not of type string', () => {
     const actual = () =>
-      metaIdentityClaims.followMetaIdentity([verifiedClaim], issuer, {
-        id: subject.id,
-      })
+      metaIdentityClaims.followMetaIdentity(
+        [verifiedClaim],
+        claim.graph,
+        issuer,
+        {
+          id: subject.id,
+        }
+      )
 
     expect(actual).toThrow()
   })

--- a/packages/identity/src/getClaimsGraphFromUsername.js
+++ b/packages/identity/src/getClaimsGraphFromUsername.js
@@ -19,14 +19,20 @@
  If you have any questions please contact yo@jaak.io
 */
 
-import createIdentityObject from './createIdentityObject'
-import getClaimsGraphFromUsername from './getClaimsGraphFromUsername'
-import getIdFromUsername from './getIdFromUsername'
-import getUsernameFromName from './getUsernameFromName'
+import { META_ID_USERNAME_SUFFIX } from '@meta.js/shared'
 
-export {
-  createIdentityObject,
-  getClaimsGraphFromUsername,
-  getIdFromUsername,
-  getUsernameFromName,
+/**
+ * Get a META Claims Graph from a `username`
+ *
+ * @param  {String} username META Identity username
+ * @return {String}          META Claims Graph name
+ */
+const getClaimsGraphFromUsername = username => {
+  if (typeof username === 'undefined' || typeof username !== 'string') {
+    throw new Error('`username` is undefined or not of type string.')
+  }
+
+  return `${username}${META_ID_USERNAME_SUFFIX}`
 }
+
+export default getClaimsGraphFromUsername

--- a/packages/identity/src/getUsernameFromName.js
+++ b/packages/identity/src/getUsernameFromName.js
@@ -19,7 +19,6 @@
  If you have any questions please contact yo@jaak.io
 */
 
-import { META_ID_USERNAME_SUFFIX } from '@meta.js/shared'
 import slugify from 'slugify'
 
 /**
@@ -33,7 +32,7 @@ const getUsernameFromName = commonName => {
     throw new Error('`commonName` is undefined or not of type string.')
   }
 
-  return `${slugify(commonName.toLowerCase())}${META_ID_USERNAME_SUFFIX}`
+  return slugify(commonName.toLowerCase())
 }
 
 export default getUsernameFromName

--- a/packages/identity/test/fixtures/graph.json
+++ b/packages/identity/test/fixtures/graph.json
@@ -1,0 +1,3 @@
+{
+  "graph": "viktor-tron.meta"
+}

--- a/packages/identity/test/fixtures/id.json
+++ b/packages/identity/test/fixtures/id.json
@@ -1,3 +1,3 @@
 {
-  "id": "0xcc1bfbdf07aaaec4dff026e54023295684af8e831c45cf514475dd65253eaced"
+  "id": "0x26a83f9109c149cbde93963cdbd8a6bc613d4e427c8ed78a1db97022e9c75dda"
 }

--- a/packages/identity/test/fixtures/identity.json
+++ b/packages/identity/test/fixtures/identity.json
@@ -1,5 +1,5 @@
 {
   "owner": "0xc4300acba32f5631ec4e45b3d62bd31f947a27e3",
-  "signature": "0x528af605360be427279da2746653f4bbf63a3bce173fe044d4b91462ffbd862e123e057e67ef06b00694e7d20c7b931637ffd9242f86a65985dd24d26eb288c801",
-  "username": "viktor-tron.id.meta"
+  "signature": "0xce460c757841d7a0c3cbe9cad9666a6a15dd2d5f0146fda2aa40ca918714e07e2e06e6c8e00055e1289b52c90682ebc3ed3d5119a02cf9114874d0b35c855cb000",
+  "username": "viktor-tron"
 }

--- a/packages/identity/test/getClaimsGraphFromUsername.spec.js
+++ b/packages/identity/test/getClaimsGraphFromUsername.spec.js
@@ -1,0 +1,29 @@
+const metaIdentity = require('../dist/meta-identity')
+
+const { graph } = require('./fixtures/graph.json')
+const identity = require('./fixtures/identity.json')
+
+describe('@meta.js/identity :: getClaimsGraphFromUsername', () => {
+  it('Should generate a META Claims Graph name', () => {
+    const { username } = identity
+
+    const actual = metaIdentity.getClaimsGraphFromUsername(username)
+    const expected = graph
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('Should throw an error if username is undefined', () => {
+    const actual = () => metaIdentity.getClaimsGraphFromUsername()
+
+    expect(actual).toThrow()
+  })
+
+  it('Should throw an error if username is not of type string', () => {
+    const username = { username: identity.username }
+
+    const actual = () => metaIdentity.getClaimsGraphFromUsername(username)
+
+    expect(actual).toThrow()
+  })
+})

--- a/packages/shared/src/constants.js
+++ b/packages/shared/src/constants.js
@@ -38,4 +38,4 @@ export const META_ID_PROFILE_CLAIM_PREFIX = 'profile.'
  *
  * @type {String}
  */
-export const META_ID_USERNAME_SUFFIX = '.id.meta'
+export const META_ID_USERNAME_SUFFIX = '.meta'

--- a/packages/shared/test/meta.spec.js
+++ b/packages/shared/test/meta.spec.js
@@ -25,7 +25,7 @@ describe('@meta.js/shared :: META_ID_PROFILE_CLAIM_PREFIX', () => {
 describe('@meta.js/shared :: META_ID_USERNAME_SUFFIX', () => {
   it('Should return META_ID_USERNAME_SUFFIX value', () => {
     const actual = metaShared.META_ID_USERNAME_SUFFIX
-    const expected = '.id.meta'
+    const expected = '.meta'
 
     expect(actual).toEqual(expected)
   })


### PR DESCRIPTION
The library has been updated to reflect changes to the META Testnet API:
- META ID suffix changed from `.id.meta` to `.meta`
- Usernames now generated _without_ suffix, as handled by go-meta
- Added new `getClaimsGraphFromUsername` method to convert a username to a graph name (eg. "bob" => "bob.meta"
- Added new `graph` property to all claim generation methods
- Updated tests and test fixtures

This will be released as `v1.0.0-beta`